### PR TITLE
[FEAT] storeId로 store name 반환하는 API 추가

### DIFF
--- a/backend/mammoth_order_backend/src/main/java/com/project/mammoth_order_backend/store/controller/StoreController.java
+++ b/backend/mammoth_order_backend/src/main/java/com/project/mammoth_order_backend/store/controller/StoreController.java
@@ -3,6 +3,7 @@ package com.project.mammoth_order_backend.store.controller;
 import com.project.mammoth_order_backend.auth.security.CustomUserDetails;
 import com.project.mammoth_order_backend.store.dto.MyStoreResponseDto;
 import com.project.mammoth_order_backend.store.dto.MyStoreSaveRequestDto;
+import com.project.mammoth_order_backend.store.dto.StoreNameResponseDto;
 import com.project.mammoth_order_backend.store.entity.Store;
 import com.project.mammoth_order_backend.store.service.StoreService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,6 +26,14 @@ public class StoreController {
     public ResponseEntity<List<Store>> getAllStores() {
         List<Store> storeList = storeService.getAllStores();
         return ResponseEntity.ok(storeList);
+    }
+
+    // 매장 이름 조회
+    @Operation(summary = "매장 이름 조회", description = "storeId를 통해 해당 매장의 이름을 반환합니다.")
+    @GetMapping("/{id}")
+    public ResponseEntity<StoreNameResponseDto> getStoreName(@PathVariable("id") Long storeId) {
+        StoreNameResponseDto storeName = storeService.getStoreName(storeId);
+        return ResponseEntity.ok(storeName);
     }
     
     // my 매장 보기

--- a/backend/mammoth_order_backend/src/main/java/com/project/mammoth_order_backend/store/dto/MyStoreResponseDto.java
+++ b/backend/mammoth_order_backend/src/main/java/com/project/mammoth_order_backend/store/dto/MyStoreResponseDto.java
@@ -9,18 +9,18 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MyStoreResponseDto {
-    @Schema(description = "MY 매장 고유 ID")
+    @Schema(description = "MY 매장 고유 ID", example = "1")
     private Long id;
 
-    @Schema(description = "사용자 ID")
+    @Schema(description = "사용자 ID", example = "6")
     private Long userId;
 
-    @Schema(description = "매장 ID")
+    @Schema(description = "매장 ID", example = "2")
     private Long storeId;
 
-    @Schema(description = "매장 이름")
+    @Schema(description = "매장 이름", example = "중림한국경제점")
     private String name;
 
-    @Schema(description = "매장 주소")
+    @Schema(description = "매장 주소", example = "서울시 중구 청파로 641, 1층(중림동)")
     private String address;
 }

--- a/backend/mammoth_order_backend/src/main/java/com/project/mammoth_order_backend/store/dto/MyStoreSaveRequestDto.java
+++ b/backend/mammoth_order_backend/src/main/java/com/project/mammoth_order_backend/store/dto/MyStoreSaveRequestDto.java
@@ -9,6 +9,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MyStoreSaveRequestDto {
-    @Schema(description = "매장 ID")
+    @Schema(description = "매장 ID", example = "1")
     private Long storeId;
 }

--- a/backend/mammoth_order_backend/src/main/java/com/project/mammoth_order_backend/store/dto/StoreNameResponseDto.java
+++ b/backend/mammoth_order_backend/src/main/java/com/project/mammoth_order_backend/store/dto/StoreNameResponseDto.java
@@ -1,0 +1,16 @@
+package com.project.mammoth_order_backend.store.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class StoreNameResponseDto {
+    @Schema(description = "매장 이름", example = "중림한국경제점")
+    private String name;
+}

--- a/backend/mammoth_order_backend/src/main/java/com/project/mammoth_order_backend/store/service/StoreService.java
+++ b/backend/mammoth_order_backend/src/main/java/com/project/mammoth_order_backend/store/service/StoreService.java
@@ -4,6 +4,7 @@ import com.project.mammoth_order_backend.auth.entity.User;
 import com.project.mammoth_order_backend.auth.repository.UserRepository;
 import com.project.mammoth_order_backend.store.dto.MyStoreResponseDto;
 import com.project.mammoth_order_backend.store.dto.MyStoreSaveRequestDto;
+import com.project.mammoth_order_backend.store.dto.StoreNameResponseDto;
 import com.project.mammoth_order_backend.store.entity.MyStore;
 import com.project.mammoth_order_backend.store.entity.Store;
 import com.project.mammoth_order_backend.store.repository.MyStoreRepository;
@@ -26,6 +27,16 @@ public class StoreService {
     public List<Store> getAllStores() {
         List<Store> storeList = storeRepository.findAll();
         return storeList;
+    }
+
+    // 매장 이름 반환
+    @Transactional(readOnly = true)
+    public StoreNameResponseDto getStoreName(Long storeId) {
+        String storeName = storeRepository.findById(storeId)
+                .orElseThrow(() -> new RuntimeException("가게를 찾을 수 없습니다."))
+                .getName();
+        StoreNameResponseDto nameResponse = new StoreNameResponseDto(storeName);
+        return nameResponse;
     }
 
     // my 매장 보기


### PR DESCRIPTION
## 🎯 관련 이슈
- Close #32 

## ✨ 변경사항
- PathVariable로 전달된 storeId를 기반으로 매장 이름을 반환하는 API를 구현
- 응답 형식은 StoreNameResponse DTO로 구성되어 있으며, 서비스 계층에서 이름을 조회
- DTO의 멤버변수에 예시 문구를 추가

## 📝 PR 유형
- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 성능 개선 (Performance Improvement)
- [ ] 문서 수정 (Documentation)
- [ ] 테스트 추가 (Test)
- [ ] 리팩토링 (Refactoring)
- [ ] 기타 (Other)
